### PR TITLE
Added badges with version number and license type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Overview
+
+![Version](https://cocoapod-badges.herokuapp.com/v/Paparazzo/badge.png)
+![License](https://img.shields.io/badge/license-MIT-blue.svg)
+
 **Paparazzo** is a component for picking and editing photos.
 
            | Key Features


### PR DESCRIPTION
I've added a couple of fancy-looking badges in your Readme:

![Version](https://cocoapod-badges.herokuapp.com/v/Paparazzo/badge.png)
![License](https://img.shields.io/badge/license-MIT-blue.svg)