### PR TITLE
Remove assert upon empty image directory path

### DIFF
--- a/Paparazzo/Core/Helpers/ImageStorage.swift
+++ b/Paparazzo/Core/Helpers/ImageStorage.swift
@@ -70,8 +70,14 @@ public final class ImageStorageImpl: ImageStorage {
     }
     
     public func removeAll() {
+        let imageDirectoryPath = ImageStorageImpl.imageDirectoryPath()
+        guard FileManager.default.fileExists(atPath: imageDirectoryPath) else {
+            ImageStorageImpl.createImageDirectoryIfNotExist()
+            return
+        }
+
         do {
-            try FileManager.default.removeItem(atPath: ImageStorageImpl.imageDirectoryPath())
+            try FileManager.default.removeItem(atPath: imageDirectoryPath)
             ImageStorageImpl.createImageDirectoryIfNotExist()
         } catch let error {
             assert(false, "Couldn't remove photo folder with error: \(error)")


### PR DESCRIPTION
Got assertion in my unit tests when trying to delete empty library. I think is should not treated as assert and fail the tests. Add check for emptiness before deletion.

```Assertion failed: Couldn't remove photo folder with error: 
Error Domain=NSCocoaErrorDomain Code=4 "Не удалось удалить «Paparazzo»." 
UserInfo={NSFilePath=/Users/ios-build/Library/Developer/CoreSimulator/Devices/36CC2858-9FFD-4833-9DEA-DF56EB07345A/data/Containers/Data/Application/02501A27-A017-49CE-85A7-90C22BA8A908/tmp/Paparazzo,
NSUnderlyingError=0x6000010525a0 {
Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}:
file /Pods/Paparazzo/Paparazzo/Core/Helpers/ImageStorage.swift, line 77
```