### PR TITLE
changed protocol conformance to `AnyObject`

### DIFF
--- a/Paparazzo/Core/DI/ServiceFactory.swift
+++ b/Paparazzo/Core/DI/ServiceFactory.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol ServiceFactory: class {
+protocol ServiceFactory: AnyObject {
     func deviceOrientationService() -> DeviceOrientationService
     func cameraService(initialActiveCameraType: CameraType) -> CameraService
     func photoLibraryLatestPhotoProvider() -> PhotoLibraryLatestPhotoProvider

--- a/Paparazzo/Core/Helpers/CameraOutputRenderView/CameraOutputRenderView.swift
+++ b/Paparazzo/Core/Helpers/CameraOutputRenderView/CameraOutputRenderView.swift
@@ -4,7 +4,7 @@ import GLKit
 import ImageSource
 import MetalKit
 
-protocol CameraOutputRenderView: class {
+protocol CameraOutputRenderView: AnyObject {
     var frame: CGRect { get set }
     var orientation: ExifOrientation { get set }
     var onFrameDraw: (() -> ())? { get set }

--- a/Paparazzo/Core/Helpers/CaptureSessionPreviewService.swift
+++ b/Paparazzo/Core/Helpers/CaptureSessionPreviewService.swift
@@ -3,7 +3,7 @@ import ImageSource
 
 /// Delete `@objc` when the problem in Swift will be resolved
 /// https://bugs.swift.org/browse/SR-55
-@objc public protocol CameraCaptureOutputHandler: class {
+@objc public protocol CameraCaptureOutputHandler: AnyObject {
     var imageBuffer: CVImageBuffer? { get set }
 }
 

--- a/Paparazzo/Core/PaparazzoPickerModule.swift
+++ b/Paparazzo/Core/PaparazzoPickerModule.swift
@@ -26,7 +26,7 @@ public struct CameraHintData {
     }
 }
 
-public protocol PaparazzoPickerModule: class {
+public protocol PaparazzoPickerModule: AnyObject {
     
     func focusOnModule()
     func dismissModule()

--- a/Paparazzo/Core/Services/Camera/CameraService.swift
+++ b/Paparazzo/Core/Services/Camera/CameraService.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 import ImageSource
 
-public protocol CameraService: class {
+public protocol CameraService: AnyObject {
     
     var isFlashAvailable: Bool { get }
     var isFlashEnabled: Bool { get }

--- a/Paparazzo/Core/Services/CroppingOverlayProviders/CroppingOverlayProvider.swift
+++ b/Paparazzo/Core/Services/CroppingOverlayProviders/CroppingOverlayProvider.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol CroppingOverlayProvider: class {
+public protocol CroppingOverlayProvider: AnyObject {
     func calculateRectToCrop(in bounds: CGRect) -> CGRect
     func croppingPath(in rect: CGRect) -> CGPath
 }

--- a/Paparazzo/Core/Services/CroppingOverlayProviders/CroppingOverlayProvidersFactory.swift
+++ b/Paparazzo/Core/Services/CroppingOverlayProviders/CroppingOverlayProvidersFactory.swift
@@ -1,4 +1,4 @@
-public protocol CroppingOverlayProvidersFactory: class {
+public protocol CroppingOverlayProvidersFactory: AnyObject {
     func circleCroppingOverlayProvider() -> CroppingOverlayProvider
     func rectangleCroppingOverlayProvider(cornerRadius: CGFloat, margin: CGFloat) -> CroppingOverlayProvider
     func heartShapeCroppingOverlayProvider() -> CroppingOverlayProvider

--- a/Paparazzo/Core/Services/DeviceOrientationService.swift
+++ b/Paparazzo/Core/Services/DeviceOrientationService.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol DeviceOrientationService: class {
+protocol DeviceOrientationService: AnyObject {
     var currentOrientation: DeviceOrientation { get }
     var onOrientationChange: ((DeviceOrientation) -> ())? { get set }
 }

--- a/Paparazzo/Core/Services/ImageCropping/ImageCroppingService.swift
+++ b/Paparazzo/Core/Services/ImageCropping/ImageCroppingService.swift
@@ -6,7 +6,7 @@ struct ImageCroppingData {
     var parameters: ImageCroppingParameters?
 }
 
-protocol ImageCroppingService: class {
+protocol ImageCroppingService: AnyObject {
     func canvasSize(completion: @escaping (CGSize) -> ())
     func imageWithParameters(completion: @escaping (ImageCroppingData) -> ())
     func croppedImage(previewImage: CGImage, completion: @escaping (CroppedImageSource) -> ())

--- a/Paparazzo/Core/Services/LocationProvider.swift
+++ b/Paparazzo/Core/Services/LocationProvider.swift
@@ -1,6 +1,6 @@
 import CoreLocation
 
-public protocol LocationProvider: class {
+public protocol LocationProvider: AnyObject {
     func location(completion: @escaping ((CLLocation?) -> ()))
 }
 

--- a/Paparazzo/Core/VIPER/Camera/Assembly/CameraAssembly.swift
+++ b/Paparazzo/Core/VIPER/Camera/Assembly/CameraAssembly.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol CameraAssembly: class {
+protocol CameraAssembly: AnyObject {
     func module(initialActiveCameraType: CameraType, overridenTheme: PaparazzoUITheme?) -> (UIView, CameraModuleInput)
 }
 

--- a/Paparazzo/Core/VIPER/Camera/Interactor/CameraInteractor.swift
+++ b/Paparazzo/Core/VIPER/Camera/Interactor/CameraInteractor.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 import ImageSource
 
-protocol CameraInteractor: class {
+protocol CameraInteractor: AnyObject {
     
     func getOutputParameters(completion: @escaping (CameraOutputParameters?) -> ())
     func setCameraOutputNeeded(_: Bool)

--- a/Paparazzo/Core/VIPER/Camera/Module/CameraModuleInput.swift
+++ b/Paparazzo/Core/VIPER/Camera/Module/CameraModuleInput.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol CameraModuleInput: class {
+protocol CameraModuleInput: AnyObject {
     
     func getOutputParameters(completion: @escaping (CameraOutputParameters?) -> ())
     func setCameraOutputNeeded(_: Bool)

--- a/Paparazzo/Core/VIPER/Camera/View/CameraViewInput.swift
+++ b/Paparazzo/Core/VIPER/Camera/View/CameraViewInput.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol CameraViewInput: class {
+protocol CameraViewInput: AnyObject {
     
     func setTitle(_: String?)
     func setSubtitle(_: String?)

--- a/Paparazzo/Core/VIPER/ImageCropping/Assembly/ImageCroppingAssembly.swift
+++ b/Paparazzo/Core/VIPER/ImageCropping/Assembly/ImageCroppingAssembly.swift
@@ -1,7 +1,7 @@
 import ImageSource
 import UIKit
 
-protocol ImageCroppingAssembly: class {
+protocol ImageCroppingAssembly: AnyObject {
     func module(
         image: ImageSource,
         canvasSize: CGSize,
@@ -9,6 +9,6 @@ protocol ImageCroppingAssembly: class {
         -> UIViewController
 }
 
-protocol ImageCroppingAssemblyFactory: class {
+protocol ImageCroppingAssemblyFactory: AnyObject {
     func imageCroppingAssembly() -> ImageCroppingAssembly
 }

--- a/Paparazzo/Core/VIPER/ImageCropping/Interactor/ImageCroppingInteractor.swift
+++ b/Paparazzo/Core/VIPER/ImageCropping/Interactor/ImageCroppingInteractor.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ImageSource
 
-protocol ImageCroppingInteractor: class {
+protocol ImageCroppingInteractor: AnyObject {
     
     func canvasSize(completion: @escaping (CGSize) -> ())
     

--- a/Paparazzo/Core/VIPER/ImageCropping/Module/ImageCroppingModule.swift
+++ b/Paparazzo/Core/VIPER/ImageCropping/Module/ImageCroppingModule.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-public protocol ImageCroppingModule: class {
+public protocol ImageCroppingModule: AnyObject {
     var onDiscard: (() -> ())? { get set }
     var onConfirm: ((ImageSource) -> ())? { get set }
 }

--- a/Paparazzo/Core/VIPER/ImageCropping/View/ImageCroppingViewInput.swift
+++ b/Paparazzo/Core/VIPER/ImageCropping/View/ImageCroppingViewInput.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ImageSource
 
-protocol ImageCroppingViewInput: class {
+protocol ImageCroppingViewInput: AnyObject {
     
     func setTitle(_: String)
     

--- a/Paparazzo/Core/VIPER/InfoMessage/InfoMessageDisplayer.swift
+++ b/Paparazzo/Core/VIPER/InfoMessage/InfoMessageDisplayer.swift
@@ -19,7 +19,7 @@ final class InfoMessageDisplayer {
     }
 }
 
-protocol InfoMessageDisplayable: class {
+protocol InfoMessageDisplayable: AnyObject {
     @discardableResult
     func showInfoMessage(_ viewData: InfoMessageViewData) -> InfoMessageViewInput
 }

--- a/Paparazzo/Core/VIPER/InfoMessage/InfoMessageViewFactory.swift
+++ b/Paparazzo/Core/VIPER/InfoMessage/InfoMessageViewFactory.swift
@@ -1,4 +1,4 @@
-protocol InfoMessageViewFactory: class {
+protocol InfoMessageViewFactory: AnyObject {
     
     func create(
         from viewData: InfoMessageViewData

--- a/Paparazzo/Core/VIPER/InfoMessage/InfoMessageViewInput.swift
+++ b/Paparazzo/Core/VIPER/InfoMessage/InfoMessageViewInput.swift
@@ -1,4 +1,4 @@
-public protocol InfoMessageViewInput: class {
+public protocol InfoMessageViewInput: AnyObject {
     func dismiss()
 }
 

--- a/Paparazzo/Core/VIPER/MaskCropper/Assembly/MaskCropperAssembly.swift
+++ b/Paparazzo/Core/VIPER/MaskCropper/Assembly/MaskCropperAssembly.swift
@@ -1,7 +1,7 @@
 import ImageSource
 import UIKit
 
-public protocol MaskCropperAssembly: class {
+public protocol MaskCropperAssembly: AnyObject {
     func module(
         data: MaskCropperData,
         croppingOverlayProvider: CroppingOverlayProvider,
@@ -9,6 +9,6 @@ public protocol MaskCropperAssembly: class {
         -> UIViewController
 }
 
-public protocol MaskCropperAssemblyFactory: class {
+public protocol MaskCropperAssemblyFactory: AnyObject {
     func maskCropperAssembly() -> MaskCropperAssembly
 }

--- a/Paparazzo/Core/VIPER/MaskCropper/Interactor/MaskCropperInteractor.swift
+++ b/Paparazzo/Core/VIPER/MaskCropper/Interactor/MaskCropperInteractor.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol MaskCropperInteractor: class {
+protocol MaskCropperInteractor: AnyObject {
     func canvasSize(completion: @escaping (CGSize) -> ())
     func imageWithParameters(completion: @escaping (ImageCroppingData) -> ())
     func croppedImage(previewImage: CGImage, completion: @escaping (CroppedImageSource) -> ())

--- a/Paparazzo/Core/VIPER/MaskCropper/Module/MaskCropperModule.swift
+++ b/Paparazzo/Core/VIPER/MaskCropper/Module/MaskCropperModule.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-public protocol MaskCropperModule: class {
+public protocol MaskCropperModule: AnyObject {
     
     func dismissModule()
     

--- a/Paparazzo/Core/VIPER/MaskCropper/Router/MaskCropperRouter.swift
+++ b/Paparazzo/Core/VIPER/MaskCropper/Router/MaskCropperRouter.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol MaskCropperRouter: class {
+protocol MaskCropperRouter: AnyObject {
     func focusOnCurrentModule()
     func dismissCurrentModule()
 }

--- a/Paparazzo/Core/VIPER/MaskCropper/View/MaskCropperViewInput.swift
+++ b/Paparazzo/Core/VIPER/MaskCropper/View/MaskCropperViewInput.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol MaskCropperViewInput: class {
+protocol MaskCropperViewInput: AnyObject {
     func setImage(_: ImageSource, previewImage: ImageSource?, completion: @escaping () -> ())
     func setCroppingParameters(_: ImageCroppingParameters)
     func setCanvasSize(_: CGSize)

--- a/Paparazzo/Core/VIPER/MediaPicker/Assembly/MediaPickerAssembly.swift
+++ b/Paparazzo/Core/VIPER/MediaPicker/Assembly/MediaPickerAssembly.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol MediaPickerAssembly: class {
+public protocol MediaPickerAssembly: AnyObject {
     func module(
         data: MediaPickerData,
         overridenTheme: PaparazzoUITheme?,
@@ -9,7 +9,7 @@ public protocol MediaPickerAssembly: class {
         -> UIViewController
 }
 
-public protocol MediaPickerAssemblyFactory: class {
+public protocol MediaPickerAssemblyFactory: AnyObject {
     func mediaPickerAssembly() -> MediaPickerAssembly
 }
 

--- a/Paparazzo/Core/VIPER/MediaPicker/Interactor/MediaPickerInteractor.swift
+++ b/Paparazzo/Core/VIPER/MediaPicker/Interactor/MediaPickerInteractor.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol MediaPickerInteractor: class {
+protocol MediaPickerInteractor: AnyObject {
     
     var items: [MediaPickerItem] { get }
     var cropCanvasSize: CGSize { get }

--- a/Paparazzo/Core/VIPER/MediaPicker/Router/MediaPickerRouter.swift
+++ b/Paparazzo/Core/VIPER/MediaPicker/Router/MediaPickerRouter.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol MediaPickerRouter: class {
+protocol MediaPickerRouter: AnyObject {
     
     func showPhotoLibrary(
         data: PhotoLibraryData,

--- a/Paparazzo/Core/VIPER/MediaPicker/View/MediaPickerViewInput.swift
+++ b/Paparazzo/Core/VIPER/MediaPicker/View/MediaPickerViewInput.swift
@@ -16,7 +16,7 @@ enum MediaPickerAutocorrectionStatus {
     case corrected
 }
 
-protocol MediaPickerViewInput: class {
+protocol MediaPickerViewInput: AnyObject {
     
     func setMode(_: MediaPickerViewMode)
     func setAutocorrectionStatus(_: MediaPickerAutocorrectionStatus)

--- a/Paparazzo/Core/VIPER/NewCamera/Assembly/NewCameraAssembly.swift
+++ b/Paparazzo/Core/VIPER/NewCamera/Assembly/NewCameraAssembly.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 // TODO: rename module to StandaloneCamera
-protocol NewCameraAssembly: class {
+protocol NewCameraAssembly: AnyObject {
     func module(
         selectedImagesStorage: SelectedImageStorage,
         mediaPickerData: MediaPickerData,
@@ -11,6 +11,6 @@ protocol NewCameraAssembly: class {
     ) -> UIViewController
 }
 
-protocol NewCameraAssemblyFactory: class {
+protocol NewCameraAssemblyFactory: AnyObject {
     func newCameraAssembly() -> NewCameraAssembly
 }

--- a/Paparazzo/Core/VIPER/NewCamera/Interactor/NewCameraInteractor.swift
+++ b/Paparazzo/Core/VIPER/NewCamera/Interactor/NewCameraInteractor.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol NewCameraInteractor: class {
+protocol NewCameraInteractor: AnyObject {
     var mediaPickerData: MediaPickerData { get }
     var selectedImagesStorage: SelectedImageStorage { get }
     var isFlashAvailable: Bool { get }

--- a/Paparazzo/Core/VIPER/NewCamera/Presenter/NewCameraModule.swift
+++ b/Paparazzo/Core/VIPER/NewCamera/Presenter/NewCameraModule.swift
@@ -3,7 +3,7 @@ enum NewCameraModuleResult {
     case cancelled
 }
 
-protocol NewCameraModule: class {
+protocol NewCameraModule: AnyObject {
     var onFinish: ((NewCameraModule, NewCameraModuleResult) -> ())? { get set }
     var configureMediaPicker: ((MediaPickerModule) -> ())? { get set }
     func focusOnModule()

--- a/Paparazzo/Core/VIPER/NewCamera/Router/NewCameraRouter.swift
+++ b/Paparazzo/Core/VIPER/NewCamera/Router/NewCameraRouter.swift
@@ -1,4 +1,4 @@
-protocol NewCameraRouter: class {
+protocol NewCameraRouter: AnyObject {
     func focusOnCurrentModule()
     
     func showMediaPicker(

--- a/Paparazzo/Core/VIPER/NewCamera/View/NewCameraViewInput.swift
+++ b/Paparazzo/Core/VIPER/NewCamera/View/NewCameraViewInput.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol NewCameraViewInput: class {
+protocol NewCameraViewInput: AnyObject {
     var onCloseButtonTap: (() -> ())? { get set }
     var onDoneButtonTap: (() -> ())? { get set }
     var onToggleCameraButtonTap: (() -> ())? { get set }

--- a/Paparazzo/Core/VIPER/PhotoLibrary/Assembly/PhotoLibraryAssembly.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibrary/Assembly/PhotoLibraryAssembly.swift
@@ -1,12 +1,12 @@
 import UIKit
 
-public protocol PhotoLibraryAssembly: class {
+public protocol PhotoLibraryAssembly: AnyObject {
     func module(
         data: PhotoLibraryData,
         configure: (PhotoLibraryModule) -> ()
     ) -> UIViewController
 }
 
-public protocol PhotoLibraryAssemblyFactory: class {
+public protocol PhotoLibraryAssemblyFactory: AnyObject {
     func photoLibraryAssembly() -> PhotoLibraryAssembly
 }

--- a/Paparazzo/Core/VIPER/PhotoLibrary/Interactor/PhotoLibraryInteractor.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibrary/Interactor/PhotoLibraryInteractor.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ImageSource
 
-protocol PhotoLibraryInteractor: class {
+protocol PhotoLibraryInteractor: AnyObject {
     
     var currentAlbum: PhotoLibraryAlbum? { get }
     var selectedItems: [PhotoLibraryItem] { get }

--- a/Paparazzo/Core/VIPER/PhotoLibrary/Module/PhotoLibraryModule.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibrary/Module/PhotoLibraryModule.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol PhotoLibraryModule: class {
+public protocol PhotoLibraryModule: AnyObject {
     
     func dismissModule()
     

--- a/Paparazzo/Core/VIPER/PhotoLibrary/Router/PhotoLibraryRouter.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibrary/Router/PhotoLibraryRouter.swift
@@ -1,3 +1,3 @@
-protocol PhotoLibraryRouter: class {
+protocol PhotoLibraryRouter: AnyObject {
     func dismissCurrentModule()
 }

--- a/Paparazzo/Core/VIPER/PhotoLibrary/View/PhotoLibraryViewInput.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibrary/View/PhotoLibraryViewInput.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ImageSource
 
-protocol PhotoLibraryViewInput: class {
+protocol PhotoLibraryViewInput: AnyObject {
     
     var onTitleTap: (() -> ())? { get set }
     var onDimViewTap: (() -> ())? { get set }

--- a/Paparazzo/Core/VIPER/PhotoLibraryV2/Assembly/PhotoLibraryV2Assembly.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibraryV2/Assembly/PhotoLibraryV2Assembly.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol PhotoLibraryV2Assembly: class {
+public protocol PhotoLibraryV2Assembly: AnyObject {
     func module(
         data: PhotoLibraryV2Data,
         isNewFlowPrototype: Bool,
@@ -8,6 +8,6 @@ public protocol PhotoLibraryV2Assembly: class {
     ) -> UIViewController
 }
 
-public protocol PhotoLibraryV2AssemblyFactory: class {
+public protocol PhotoLibraryV2AssemblyFactory: AnyObject {
     func photoLibraryV2Assembly() -> PhotoLibraryV2Assembly
 }

--- a/Paparazzo/Core/VIPER/PhotoLibraryV2/Interactor/PhotoLibraryV2Interactor.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibraryV2/Interactor/PhotoLibraryV2Interactor.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ImageSource
 
-protocol PhotoLibraryV2Interactor: class {
+protocol PhotoLibraryV2Interactor: AnyObject {
     
     var mediaPickerData: MediaPickerData { get }
     var currentAlbum: PhotoLibraryAlbum? { get }

--- a/Paparazzo/Core/VIPER/PhotoLibraryV2/Router/PhotoLibraryV2Router.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibraryV2/Router/PhotoLibraryV2Router.swift
@@ -1,4 +1,4 @@
-protocol PhotoLibraryV2Router: class {
+protocol PhotoLibraryV2Router: AnyObject {
     func dismissCurrentModule()
     func focusOnCurrentModule()
     

--- a/Paparazzo/Core/VIPER/PhotoLibraryV2/View/PhotoLibraryV2ViewInput.swift
+++ b/Paparazzo/Core/VIPER/PhotoLibraryV2/View/PhotoLibraryV2ViewInput.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ImageSource
 
-protocol PhotoLibraryV2ViewInput: class {
+protocol PhotoLibraryV2ViewInput: AnyObject {
     
     var onTitleTap: (() -> ())? { get set }
     var onDimViewTap: (() -> ())? { get set }

--- a/Paparazzo/Core/VIPER/Scanner/Assembly/ScannerAssembly.swift
+++ b/Paparazzo/Core/VIPER/Scanner/Assembly/ScannerAssembly.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol ScannerAssembly: class {
+public protocol ScannerAssembly: AnyObject {
     func module(
         data: ScannerData,
         overridenTheme: PaparazzoUITheme?,
@@ -8,7 +8,7 @@ public protocol ScannerAssembly: class {
         -> UIViewController
 }
 
-public protocol ScannerAssemblyFactory: class {
+public protocol ScannerAssemblyFactory: AnyObject {
     func scannerAssembly() -> ScannerAssembly
 }
 

--- a/Paparazzo/Core/VIPER/Scanner/Interactor/ScannerInteractor.swift
+++ b/Paparazzo/Core/VIPER/Scanner/Interactor/ScannerInteractor.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol ScannerInteractor: class {
+protocol ScannerInteractor: AnyObject {
     
     func observeDeviceOrientation(handler: @escaping (DeviceOrientation) -> ())
     

--- a/Paparazzo/Core/VIPER/Scanner/Module/ScannerModule.swift
+++ b/Paparazzo/Core/VIPER/Scanner/Module/ScannerModule.swift
@@ -1,4 +1,4 @@
-public protocol ScannerModule: class {
+public protocol ScannerModule: AnyObject {
 
     func focusOnModule()
     func dismissModule()

--- a/Paparazzo/Core/VIPER/Scanner/Router/ScannerRouter.swift
+++ b/Paparazzo/Core/VIPER/Scanner/Router/ScannerRouter.swift
@@ -1,6 +1,6 @@
 import ImageSource
 
-protocol ScannerRouter: class {
+protocol ScannerRouter: AnyObject {
     
     func focusOnCurrentModule()
     func dismissCurrentModule()

--- a/Paparazzo/Core/VIPER/Scanner/View/ScannerViewInput.swift
+++ b/Paparazzo/Core/VIPER/Scanner/View/ScannerViewInput.swift
@@ -1,7 +1,7 @@
 import ImageSource
 import UIKit
 
-protocol ScannerViewInput: class {
+protocol ScannerViewInput: AnyObject {
     
     func adjustForDeviceOrientation(_: DeviceOrientation)
     

--- a/Paparazzo/Marshroute/MaskCropper/Assembly/MaskCropperMarshrouteAssembly.swift
+++ b/Paparazzo/Marshroute/MaskCropper/Assembly/MaskCropperMarshrouteAssembly.swift
@@ -1,7 +1,7 @@
 import Marshroute
 import UIKit
 
-public protocol MaskCropperMarshrouteAssembly: class {
+public protocol MaskCropperMarshrouteAssembly: AnyObject {
     func module(
         data: MaskCropperData,
         croppingOverlayProvider: CroppingOverlayProvider,
@@ -10,6 +10,6 @@ public protocol MaskCropperMarshrouteAssembly: class {
         -> UIViewController
 }
 
-public protocol MaskCropperMarshrouteAssemblyFactory: class {
+public protocol MaskCropperMarshrouteAssemblyFactory: AnyObject {
     func maskCropperAssembly() -> MaskCropperMarshrouteAssembly
 }

--- a/Paparazzo/Marshroute/MediaPicker/Assembly/MediaPickerMarshrouteAssembly.swift
+++ b/Paparazzo/Marshroute/MediaPicker/Assembly/MediaPickerMarshrouteAssembly.swift
@@ -1,7 +1,7 @@
 import Marshroute
 import UIKit
 
-public protocol MediaPickerMarshrouteAssembly: class {
+public protocol MediaPickerMarshrouteAssembly: AnyObject {
     func module(
         data: MediaPickerData,
         overridenTheme: PaparazzoUITheme?,
@@ -12,7 +12,7 @@ public protocol MediaPickerMarshrouteAssembly: class {
         -> UIViewController
 }
 
-public protocol MediaPickerMarshrouteAssemblyFactory: class {
+public protocol MediaPickerMarshrouteAssemblyFactory: AnyObject {
     func mediaPickerAssembly() -> MediaPickerMarshrouteAssembly
 }
 

--- a/Paparazzo/Marshroute/NewCamera/Assembly/NewCameraMarshrouteAssembly.swift
+++ b/Paparazzo/Marshroute/NewCamera/Assembly/NewCameraMarshrouteAssembly.swift
@@ -2,7 +2,7 @@ import Marshroute
 import UIKit
 
 // TODO: rename module to StandaloneCamera
-protocol NewCameraMarshrouteAssembly: class {
+protocol NewCameraMarshrouteAssembly: AnyObject {
     func module(
         selectedImagesStorage: SelectedImageStorage,
         mediaPickerData: MediaPickerData,
@@ -13,6 +13,6 @@ protocol NewCameraMarshrouteAssembly: class {
     ) -> UIViewController
 }
 
-protocol NewCameraMarshrouteAssemblyFactory: class {
+protocol NewCameraMarshrouteAssemblyFactory: AnyObject {
     func newCameraAssembly() -> NewCameraMarshrouteAssembly
 }

--- a/Paparazzo/Marshroute/PhotoLibrary/Assembly/PhotoLibraryMarshrouteAssembly.swift
+++ b/Paparazzo/Marshroute/PhotoLibrary/Assembly/PhotoLibraryMarshrouteAssembly.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Marshroute
 
-public protocol PhotoLibraryMarshrouteAssembly: class {
+public protocol PhotoLibraryMarshrouteAssembly: AnyObject {
     func module(
         selectedItems: [PhotoLibraryItem],
         maxSelectedItemsCount: Int?,
@@ -10,6 +10,6 @@ public protocol PhotoLibraryMarshrouteAssembly: class {
         -> UIViewController
 }
 
-public protocol PhotoLibraryMarshrouteAssemblyFactory: class {
+public protocol PhotoLibraryMarshrouteAssemblyFactory: AnyObject {
     func photoLibraryAssembly() -> PhotoLibraryMarshrouteAssembly
 }

--- a/Paparazzo/Marshroute/PhotoLibraryV2/Assembly/PhotoLibraryV2MarshrouteAssembly.swift
+++ b/Paparazzo/Marshroute/PhotoLibraryV2/Assembly/PhotoLibraryV2MarshrouteAssembly.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Marshroute
 
-public protocol PhotoLibraryV2MarshrouteAssembly: class {
+public protocol PhotoLibraryV2MarshrouteAssembly: AnyObject {
     func module(
         mediaPickerData: MediaPickerData,
         selectedItems: [PhotoLibraryItem],
@@ -29,6 +29,6 @@ public extension PhotoLibraryV2MarshrouteAssembly {
     }
 }
 
-public protocol PhotoLibraryV2MarshrouteAssemblyFactory: class {
+public protocol PhotoLibraryV2MarshrouteAssemblyFactory: AnyObject {
     func photoLibraryV2Assembly() -> PhotoLibraryV2MarshrouteAssembly
 }

--- a/Paparazzo/Marshroute/Scanner/Assembly/ScannerMarshrouteAssembly.swift
+++ b/Paparazzo/Marshroute/Scanner/Assembly/ScannerMarshrouteAssembly.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Marshroute
 
-public protocol ScannerMarshrouteAssembly: class {
+public protocol ScannerMarshrouteAssembly: AnyObject {
     func module(
         data: ScannerData,
         routerSeed: RouterSeed,
@@ -20,6 +20,6 @@ public extension ScannerMarshrouteAssembly {
     }
 }
 
-public protocol ScannerMarshrouteAssemblyFactory: class {
+public protocol ScannerMarshrouteAssemblyFactory: AnyObject {
     func scannerAssembly() -> ScannerMarshrouteAssembly
 }


### PR DESCRIPTION
Referencing issue #82 

Changed all protocols currently requiring the [deprecated `class` conformance](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md#class-and-anyobject) to require `AnyObject` conformance instead 